### PR TITLE
Update key-policy.md

### DIFF
--- a/key-policy.md
+++ b/key-policy.md
@@ -3,8 +3,8 @@
 * get to know the people who work around you! we encourage interaction among members, both socially and professionally.
 * use the Face Wall to put names with faces: that’s what it’s there for. 
 
-#####Catapult membership and pricing are flexible.
-* we understand that ability to pay may vary and that members use the space in different ways. 
+#####Catapult membership and pricing are flexible, with the intention of fostering a space built on gifts, rather than demands...a free flow of value (money and human capital) added to and taken from the space, because we understand that ability to pay may vary and that members use the space in different ways. 
+* this is not a typical donation model such as NPR where each member assumes others are covering their costs. there are no members covering your costs, and all payments are public, as catapult financial information is available to all members
 * you can make one-time, weekly, or re-curring monthly contributions via our website (www.catapultpgh.org), where you'll find suggested rates.
 * there are no contracts or long-term commitments.
 * everyone has access to catapult amenities (printing, coffee, keg, etc.), regardless of membership level.
@@ -13,7 +13,7 @@
 * keeping the work surfaces clean
 * emptying the kitchen trash can when it’s full
 * cleaning out your old food from the fridge
-* loading | unloading the dishwasher
+* loading / unloading the dishwasher
 * generally cleaning up any messes you make
 
 #####The street entrance is unlocked between 8 a.m. and 6 p.m. on weekdays. 
@@ -23,6 +23,7 @@
 #####It’s up to you to get involved!
 * we have a system of stewards for things like maintenance, capital improvements, social events, finances, and community culture. ask around to figure out who they are if you want to help out in any way.
 * if you have questions or suggestions, grab another member and have a conversation about it. also, come to happy hours and town hall meetings (check bulletin boards and slack for more info).
+* if you want to do something to improve the space: apologize, don't ask for permission.
 
 #### How to Become a Member of Catapult PGH
 ##### Keys to the Castle
@@ -41,44 +42,11 @@
 
 ***
 
-##### For info about... talk to... 
-######Space Ops/Maintenence
-* Katharine Kidd
-* Phip
-
-***
-
-######Moneys, Anonymous Donations
-
-* Elliott Williams
-* Cat Sheane
-* Chad 
-
-***
-###### Capital Improvements / Beautification / Labelification
-
-* Boyd Bryant
-* Elliott Williams
-
-***
-###### Social Events
-
-
-
-***
-###### Digital/Website
-
-* Jim
-* Jesse
-
-
-***
-###### Culture/Etiquette/Vibe
-
-* Adam Ratana
-* Sarah Reed
-* Pete Fein
-* Elliott Williams
-* Chris Maury
-* Greg Nicholas
-* Matt Marks
+For info about... | talk to... 
+------------------|-----------
+Space Ops/Maintenence | Katharine Kidd, Phip
+Moneys, Anonymous Donations | Elliott Williams, Cat Sheane, Chad 
+Capital Improvements / Beautification / Labelification | Boyd Bryant, Elliott Williams
+Social Events |
+Digital/Website | Jim, Jesse
+Culture/Etiquette/Vibe | Adam Ratana, Sarah Reed, Pete Fein, Elliott Williams, Chris Maury, Greg Nicholas, Matt Marks

--- a/key-policy.md
+++ b/key-policy.md
@@ -1,66 +1,84 @@
-# How to Become a Member of Catapult PGH
+####Welcome to Catapult PGH! Here's some info we think you might like to know:
+#####Catapult is a community first and a space second. 
+* get to know the people who work around you! we encourage interaction among members, both socially and professionally.
+* use the Face Wall to put names with faces: that’s what it’s there for. 
 
+#####Catapult membership and pricing are flexible.
+* we understand that ability to pay may vary and that members use the space in different ways. 
+* you can make one-time, weekly, or re-curring monthly contributions via our website (www.catapultpgh.org), where you'll find suggested rates.
+* there are no contracts or long-term commitments.
+* everyone has access to catapult amenities (printing, coffee, keg, etc.), regardless of membership level.
 
-## Things People Need to Learn
+#####We all rely on each other to take care of the space. Please be a responsible member of the community by:
+* keeping the work surfaces clean
+* emptying the kitchen trash can when it’s full
+* cleaning out your old food from the fridge
+* loading | unloading the dishwasher
+* generally cleaning up any messes you make
 
-* Make coffee
-* get on slack
-* learn how the conference works
-* mailboxes
-* facewall
-* trash recycling
-* dish policy
+#####The street entrance is unlocked between 8 a.m. and 6 p.m. on weekdays. 
+* it also is open on weekend days when members are here, which is often, but not always. 
+* once you’ve settled in as a member, you may obtain a key for full access (see "Keys to the Castle" below). 
+
+#####It’s up to you to get involved!
+* we have a system of stewards for things like maintenance, capital improvements, social events, finances, and community culture. ask around to figure out who they are if you want to help out in any way.
+* if you have questions or suggestions, grab another member and have a conversation about it. also, come to happy hours and town hall meetings (check bulletin boards and slack for more info).
+
+#### How to Become a Member of Catapult PGH
+##### Keys to the Castle
+**There’s no lock that can protect a space from people with keys.** Instead of seeing this as an obstacle, we see it as an opportunity. In order to integrate new members, we ask that they get signatures from at least 4 current members. This gives members a chance to meet “The New Kid” and also show new members all the quirks of the space. After you've settled in as a member, if you need a key for off-hour access, that can be arranged.
+
+##### Things People Need to Learn
+
+* make coffee  [signature: _______________________________]
+* get on slack  [signature: ______________________________]
+* other communication/events  [signature: __________________________]
+* conference room scheduling  [signature: __________________________]
+* mailboxes [signature: ______________________________]
+* facewall [signature: __________________________]
+* trash recycling [signature: _____________________________]
+* dish policy [signature:  _____________________________]
 
 ***
 
-## Talk about...
-### Space Ops/Maintenence
-* Description
+##### For info about... talk to... 
+######Space Ops/Maintenence
+* Katharine Kidd
 * Phip
 
 ***
 
-### Moneys
+######Moneys, Anonymous Donations
 
-* Elliott
-* Cat
-
-***
-### Capital Improvements / Beautification / Labelification
-
-* Boyd
-* Elliott
+* Elliott Williams
+* Cat Sheane
+* Chad 
 
 ***
-### Social Events
+###### Capital Improvements / Beautification / Labelification
+
+* Boyd Bryant
+* Elliott Williams
+
+***
+###### Social Events
 
 
 
 ***
-### Digital
+###### Digital/Website
 
 * Jim
 * Jesse
 
 
 ***
-### Culture/Etequtte/Vibe
+###### Culture/Etiquette/Vibe
 
 * Adam Ratana
-* Sarah
+* Sarah Reed
 * Pete Fein
 * Elliott Williams
 * Chris Maury
 * Greg Nicholas
 * Matt Marks
-
-***
-## Anonymous Donations
-
-* Chad
-* Elliott
-
-***
-## Keys to the Castle
-
-Catapult is a community first and a space second. We all rely on each other to take care of the space. **There’s no lock that can protect a space from people with keys.** Instead of seeing this as an obstacle, we see it as an opportunity. In order for new members to get keys, new members need to get signatures from 4 current members. This gives members a chance to meet “The New Kid” and also show new members all the quirks of the space.


### PR DESCRIPTION
Added text from the "five things you need to know" document before the membership/key info, modified the text in an attempt to reflect discussion at the town hall mtg and other feedback i've received.  i think the statement about suggested rates is vague enough that if we want to modify the info on the website and/or provide other coworking space rates as a comparison we can do that and this language will still apply.  
Attempted to make it clear in the "keys to the castle" section that the orientation/signature steps should happen regardless of whether or not you want a key.
Added people's last names where i knew them, and a line for people sign next to the things to learn (probably a better way to format this but i don't know how)
Combined Moneys and Anonymous Donations into one category (if people are specifically interested in gratipay or more info about the donation model, i will direct them to Chad and Elliott)
Questions:
1. Do we want to link specific individuals to the "things to learn" list, or just allow people to put two and two together? 
2. Can the "Talk to... about..." section be formatted a little more like a table? I don't know how to do this within github.
